### PR TITLE
Test.yml: remove allow-failure

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -42,7 +42,6 @@ jobs:
           - windows-latest
         arch:
           - x64
-        allow_failure: [false]
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
`allow-failure: false` is the default,  Adding it in the matrix, breaks subsequent include: modifications.  E.g. see this run on [TulipaIO](https://github.com/TulipaEnergy/TulipaIO.jl/actions/runs/7977712404).  Instead of overiding `allow-failure`, it creates duplicate runs.

This is inline with the [docs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations). See the rule for `{fruit:banana}`.