### PR TITLE
Add copy, recopy, and update from copier and change the generate API

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -41,6 +41,8 @@ jobs:
         uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          TMPDIR: "${{ runner.temp }}"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning].
 
 - New question: SimplifiedPRTest to simplify the testing on Pull Requests (#105)
 - New question: AddAllcontributors to add a section and config for <https://allcontributors.org> (#26)
+- `copy`, `recopy` and `update` from the copier API (#142)
+
+### Changed
+
+- Adds `data` positional argument to `generate` (#142)
 
 ### Removed
 

--- a/src/COPIERTemplate.jl
+++ b/src/COPIERTemplate.jl
@@ -1,3 +1,11 @@
+"""
+# COPIERTemplate.jl
+
+This package defines a copier template for Julia packages and a basic user interface aroud copier
+to use it from Julia.
+
+The main functions are: [`generate`](@ref)
+"""
 module COPIERTemplate
 
 using PythonCall, CondaPkg, UUIDs
@@ -7,24 +15,60 @@ function __init__()
 end
 
 """
-    generate(dst_path; kwargs...)
-    generate(src_path, dst_path; kwargs...)
+    copy(dst_path[, data]; kwargs...)
+    copy(src_path, dst_path[, data]; kwargs...)
 
-Runs the `copy` command of [copier](https://github.com/copier-org/copier) with the COPIERTemplate template.
-
-If `src_path` is not informed, the GitHub URL of COPIERTemplate.jl is used.
-
-Even though the template is available offline through this template, this uses the github URL to allow updating.
-
-The keyword arguments are passed directly to the `run_copy` function of `copier`.
+Wrapper around Python's [copier.run_copy](https://copier.readthedocs.io/en/stable/reference/main/#copier.main.run_copy).
+Use [`generate`](@ref) for a more user-friendly function.
 """
-function generate(src_path, dst_path; kwargs...)
+function Base.copy(src_path, dst_path, data::Dict = Dict(); kwargs...)
   copier = PythonCall.pyimport("copier")
-  copier.run_copy(src_path, dst_path; kwargs..., vcs_ref = "HEAD")
+  copier.run_copy(src_path, dst_path, data; kwargs...)
 end
 
-function generate(dst_path, args...; kwargs...)
-  generate("https://github.com/abelsiqueira/COPIERTemplate.jl", dst_path, args...; kwargs...)
+function Base.copy(dst_path, data::Dict = Dict(); kwargs...)
+  copy(joinpath(@__DIR__, ".."), dst_path, data; kwargs...)
+end
+
+"""
+    recopy(dst_path[, data]; kwargs...)
+
+Wrapper around Python's [copier.run_recopy](https://copier.readthedocs.io/en/stable/reference/main/#copier.main.run_recopy).
+"""
+function recopy(dst_path, data::Dict = Dict(); kwargs...)
+  copier = PythonCall.pyimport("copier")
+  copier.run_recopy(dst_path, data; kwargs...)
+end
+
+"""
+    update(dst_path[, data]; kwargs...)
+
+Wrapper around Python's [copier.run_update](https://copier.readthedocs.io/en/stable/reference/main/#copier.main.run_update).
+"""
+function update(dst_path, data::Dict = Dict(); kwargs...)
+  copier = PythonCall.pyimport("copier")
+  copier.run_update(dst_path, data; kwargs...)
+end
+
+"""
+    generate(dst_path[, data]; kwargs...)
+    generate(src_path, dst_path[, data]; true, kwargs...)
+
+Runs the `copy` command of [copier](https://github.com/copier-org/copier) with the COPIERTemplate template.
+If `src_path` is not informed, the GitHub URL of COPIERTemplate.jl is used.
+
+The `data` argument is a dictionary of answers (values) to questions (keys) that can be used to bypass some of the interactive questions.
+
+## Keyword arguments
+
+The keyword arguments are passed directly to [`copy`](@ref).
+"""
+function generate(src_path, dst_path, data::Dict = Dict(); kwargs...)
+  copy(src_path, dst_path, data; kwargs...)
+end
+
+function generate(dst_path, data::Dict = Dict(); kwargs...)
+  generate("https://github.com/abelsiqueira/COPIERTemplate.jl", dst_path, data; kwargs...)
 end
 
 end


### PR DESCRIPTION
Adds copy, recopy, and update, following the copier API.
Change generate to accept a positional argument `data`.

Closes #136 