### PR TITLE
Use lowercase on UUID because of TagBot

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "BestieTemplate"
-uuid = "E5D671A7-4186-4F1A-BF88-C19B630DA94F"
+uuid = "e5d671a7-4186-4f1a-bf88-c19b630da94f"
 authors = ["Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors"]
 version = "0.7.1"
 


### PR DESCRIPTION
Julia registry has this package with the lowercase UUID. Since TagBot checks the UUID of the package
against the registry, it doesn't find it.

Closes #294

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #294

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
