### PR TITLE
workflows: fix doc generation check

### DIFF
--- a/.github/scripts/check-docs.bash
+++ b/.github/scripts/check-docs.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+declare repo=$1
+
+while IFS= read -r -d '' f; do
+    f=${f/src/build}; # <repo>/docs/src/<path> -> <repo>/docs/build/<path>
+    case $f in
+        *index.md)		# <path>/index.md -> <path>/index.html
+	    f=${f/%.md/.html};;
+        *)			# <path>/<rest>.md -> <path>/<rest>/index.html
+	    f=${f/%.md//index.html};;
+    esac
+    [[ ! -e $f ]] && { echo "$f" missing; }
+done < <(find "$repo/docs/" -type f -name '*.md' -print0 ) | grep missing
+[[ $? -ne 0 ]]

--- a/.github/workflows/TestGeneratedPkg.yml
+++ b/.github/workflows/TestGeneratedPkg.yml
@@ -70,13 +70,4 @@ jobs:
             -L tmp/Guldasta.jl/docs/make.jl
       - name: Check docs generation
         run: |
-          while IFS= read -r -d '' f; do
-            f=${f/src/build};
-            # Converts path/file.md to path/file/index.html (index.md just changes to index.html)
-            case $f in
-              *index.md) f=${f/%.md/.html};;
-              *) f=${f/%.md//index.html};;
-            esac
-            [[ -e $f ]] || { echo $f missing; }
-          done < <(find tmp/Guldasta.jl/docs/ -type f -name '*.md' -print0 ) | grep missing
-          [[ $? -ne 0 ]]
+          ./.github/scripts/check-docs.bash tmp/Guldasta.jl


### PR DESCRIPTION
GH runs custom steps as `bash -e` (`errexit`), which means any command
failure leads to the shell terminating.  To simplify this complexity,
factor out to a dedicated script, which we can now also check with
shellcheck.

[TestGeneratedPkgs on my fork](https://github.com/suvayu/COPIERTemplate.jl/actions/runs/9799231708) :white_check_mark:

Note: `shellcheck` says the last line could be `if ! cmd`, but for this script that would be rather cumbersome, so I ignored it. ([SC2181](https://www.shellcheck.net/wiki/SC2181))

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #322

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
