### PR TITLE
Create apply function and change generate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning].
 - (breaking change) GitHub PR template is now part of the minimal options (#308)
 - (breaking change) TestOnPRs.yml is now part of the minimal options (#312)
 - (breaking change) 90-contributing.md and 91-developer.md have moved from minimal to recommended. If you use the minimal option, then these files will be removed (#313)
+- (breaking change) `generate` does not work on existing folders anymore. The function `apply` was created to handle that case (#301)
 
 ### Removed
 

--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
 CondaPkg = "0.2"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ then:
 
 ```julia-repl
 julia> using BestieTemplate
-julia> BestieTemplate.generate("YourPackage.jl")
+julia> BestieTemplate.generate("path/to/YourNewPackage.jl")
+julia> # or BestieTemplate.apply("path/to/YourExistingPackage.jl")
 ```
 
 please note that `"YourPackage.jl"` can either be a fresh new package or an existing one.

--- a/copier.yml
+++ b/copier.yml
@@ -130,16 +130,4 @@ _skip_if_exists:
 _subdirectory: template
 
 _message_after_copy: |
-  Your package {{ PackageName }}.jl has been created successfully! 🎉
-
-  Next steps: Create git repository and push to Github.
-  $ cd <path>
-  $ git init
-  $ git add .
-  $ pre-commit run -a # Try to fix possible pre-commit issues (failures are expected)
-  $ git add .
-  $ git commit -m "First commit"
-  $ pre-commit install # Future commits can't be directly to main unless you use -n
-  Create a repo on GitHub and push your code to it.
-
-  Read the full guide: https://abelsiqueira.com/BestieTemplate.jl/stable/10-full-guide
+  All went well on copier's side. Going back to BestieTemplate.

--- a/docs/src/10-full-guide.md
+++ b/docs/src/10-full-guide.md
@@ -114,10 +114,11 @@ To apply the template to an existing package, you can do the following:
 
 !!! warning "git"
     This assumes that you already use git on that package and the your working directory is clean.
+    It will fail otherwise.
 
 ```julia-repl
 julia> using BestieTemplate
-julia> BestieTemplate.generate("full/path/to/YourPackage.jl")
+julia> BestieTemplate.apply("full/path/to/YourPackage.jl")
 ```
 
 This will look for a file `Project.toml` at the root of the given path and use the information there to guess some of the answers.
@@ -126,14 +127,14 @@ Currently, we guess the `PackageName`, `PackageUUID` from the `name` and `uuid` 
 !!! tip "Overwrite"
     You will be asked whether to overwrite existing files or not. Since you are using `git`, you can try it out and reset if you don't like the result.
 
-If you don't like the result, or want to override the answers, you can run the `generate` function with additional arguments:
+If you don't like the result, or want to override the answers, you can run the `apply` function with additional arguments:
 
 ```julia-repl
 julia> data = Dict("AuthorName" => "Bob", "AuthorEmail" => "bob@bob.br")
-julia> BestieTemplate.generate("full/path/to/YourPackage.jl", data)
+julia> BestieTemplate.apply("full/path/to/YourPackage.jl", data)
 ```
 
-See the full docstring for [`BestieTemplate.generate`](@ref) for more information.
+See the full docstring for [`BestieTemplate.apply`](@ref) for more information.
 
 You will most likely have conflicts when you apply the template.
 Whenever a conflict appears, you will need to decide on whether to accept or reject the new changes.
@@ -268,7 +269,7 @@ The next time that the tests are run, the coverage page will be updated, and the
 
 !!! warning "Copier.yml is work in progress"
     This option is not selected by default because it is a work in progress.
-    If you want to use it, you have to pass the key `"AddCopierCI" => true` to the `data` argument of `generate`, or select "Ask me" when deciding how to answer the optional questions.
+    If you want to use it, you have to pass the key `"AddCopierCI" => true` to the `data` argument of `generate` or `apply`, or select "Ask me" when deciding how to answer the optional questions.
 
 You can reapply the template in the future. This is normally a manual job, specially because normally there are conflicts.
 That being said, we are experimenting with having a workflow that automatically checks whether there are updates to the template and reapplies it.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -24,7 +24,8 @@ However, if you kinda know what you need to do, this is the TL;DR:
 
 ```julia-repl
 julia> using BestieTemplate
-julia> BestieTemplate.generate("YourPackage.jl")
+julia> BestieTemplate.generate("path/to/YourNewPackage.jl")
+julia> # or BestieTemplate.apply("path/to/YourExistingPackage.jl")
 ```
 
 I really recommend checking the [full guide](@ref full_guide), though.


### PR DESCRIPTION
BestieTemplate.generate only works for new folders now.
BestieTemplate.apply was created to handle existing folders.

Closes #301
    
Breaking change: generate stops working for existing packages and apply should be used instead.