### PR TITLE
Clean up docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,30 +5,16 @@ DocMeta.setdocmeta!(BestieTemplate, :DocTestSetup, :(using BestieTemplate); recu
 
 const page_rename = Dict("developer.md" => "Developer docs") # Without the numbers
 
-function nice_name(file)
-  file = replace(file, r"^[0-9]*-" => "")
-  if haskey(page_rename, file)
-    return page_rename[file]
-  end
-  return splitext(file)[1] |> x -> replace(x, "-" => " ") |> titlecase
-end
-
 makedocs(;
   modules = [BestieTemplate],
-  doctest = true,
-  linkcheck = false, # Rely on Lint.yml/lychee for the links
   authors = "Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors",
   repo = "https://github.com/abelsiqueira/BestieTemplate.jl/blob/{commit}{path}#{line}",
   sitename = "BestieTemplate.jl",
-  format = Documenter.HTML(;
-    prettyurls = true,
-    canonical = "https://abelsiqueira.github.io/BestieTemplate.jl",
-    assets = ["assets/style.css"],
-  ),
+  format = Documenter.HTML(; canonical = "https://abelsiqueira.github.io/BestieTemplate.jl"),
   pages = [
-    "Home" => "index.md"
+    "index.md"
     [
-      nice_name(file) => file for
+      file for
       file in readdir(joinpath(@__DIR__, "src")) if file != "index.md" && splitext(file)[2] == ".md"
     ]
   ],

--- a/template/docs/make.jl.jinja
+++ b/template/docs/make.jl.jinja
@@ -5,33 +5,19 @@ DocMeta.setdocmeta!({{ PackageName }}, :DocTestSetup, :(using {{ PackageName }})
 
 const page_rename = Dict("developer.md" => "Developer docs") # Without the numbers
 
-function nice_name(file)
-  file = replace(file, r"^[0-9]*-" => "")
-  if haskey(page_rename, file)
-    return page_rename[file]
-  end
-  return splitext(file)[1] |> x -> replace(x, "-" => " ") |> titlecase
-end
-
 makedocs(;
   modules = [{{ PackageName }}],
-  doctest = true,
-  linkcheck = false, # Rely on Lint.yml/lychee for the links
   authors = "{{ AuthorName }} <{{ AuthorEmail }}> and contributors",
   repo = "https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/{commit}{path}#{line}",
   sitename = "{{ PackageName }}.jl",
-  format = Documenter.HTML(;
-    prettyurls = true,
-    canonical = "https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl",
-    assets = ["assets/style.css"],
-  ),
+  format = Documenter.HTML(; canonical = "https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl"),
   pages = [
-    "Home" => "index.md"
+    "index.md"
     [
-      nice_name(file) => file for
+      file for
       file in readdir(joinpath(@__DIR__, "src")) if file != "index.md" && splitext(file)[2] == ".md"
     ]
   ],
 )
 
-deploydocs(; repo = "github.com/{{ PackageOwner }}/{{ PackageName }}.jl", push_preview = true)
+deploydocs(; repo = "github.com/{{ PackageOwner }}/{{ PackageName }}.jl")


### PR DESCRIPTION
Remove some options that are set for default values.
Remove nice_name and let Documenter use the title of the page.
Remove link_check=false to make Documenter run the link checker.

Closes #357
