### PR TITLE
Validate PackageName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning].
 
 - Update pre-commit hook versions
   - JuliaFormatter 1.0.56 -> 1.0.58
+- Validate package name to enforce capital first letter and letters and numbers (#373)
 
 ## [0.9.0] - 2024-07-13
 

--- a/copier.yml
+++ b/copier.yml
@@ -2,7 +2,13 @@
 PackageName:
   type: str
   help: Package name (without '.jl')
-  validator: "{% if PackageName | length == 0 %}Can't be empty{% endif %}"
+  validator: |
+    {% if PackageName | length == 0 %}
+    Can't be empty
+    {% endif %}
+    {% if not (PackageName | regex_search('^[A-Z][A-z0-9]*$')) %}
+    Must start with a capital letter, and use letters or numbers only
+    {% endif %}
 
 PackageUUID:
   type: str

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ end
 
 using BestieTemplate
 using Pkg
+using PythonCall
 using Test
 using YAML
 
@@ -284,6 +285,23 @@ end
         )
         answers = YAML.load_file("some_folder/SomePackage2.jl/.copier-answers.yml")
         @test answers["PackageName"] == "OtherName"
+      end
+    end
+  end
+
+  @testset "Test that bad PackageName gets flagged" begin
+    mktempdir(TMPDIR; prefix = "valid_pkg_name_") do dir
+      cd(dir) do
+        for name in ["Bad.jl", "0Bad", "bad"]
+          data = copy(template_options)
+          data["PackageName"] = name
+          @test_throws PythonCall.Core.PyException BestieTemplate.generate(
+            template_path,
+            ".",
+            data,
+            vcs_ref = "HEAD",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
Uses regex to make sure that the package name starts with a capital letter and contains only letters and numbers.

Closes #373

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide to the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
