### PR TITLE
Guess on apply for pkg already using copier

### DIFF
--- a/src/BestieTemplate.jl
+++ b/src/BestieTemplate.jl
@@ -142,16 +142,14 @@ function apply(src_path, dst_path, data::Dict = Dict(); warn_existing_pkg = true
   end
 
   # If there are answers in the destination path, skip guessing the answers
-  if !isfile(joinpath(dst_path, ".copier-answers"))
-    existing_data = _read_data_from_existing_path(dst_path)
-    for (key, value) in existing_data
-      @info "Inferred $key=$value from destination path"
-      if haskey(data, key)
-        @info "  Being overriden by supplied $key=$(data[key]) value"
-      end
+  existing_data = _read_data_from_existing_path(dst_path)
+  for (key, value) in existing_data
+    @info "Inferred $key=$value from destination path"
+    if haskey(data, key)
+      @info "  Being overriden by supplied $key=$(data[key]) value"
     end
-    data = merge(existing_data, data)
   end
+  data = merge(existing_data, data)
 
   _copy(src_path, dst_path, data; kwargs...)
 


### PR DESCRIPTION
Even if the dst_path contains a .copier-answers.yml file,
guess the starting answers. This only happens if the user
explicitly uses warn_existing_pkg=false, so it is in line
with the expectations.

Closes #383
