### PR TITLE
Remove type piracy of Base.copy

### DIFF
--- a/src/Copier.jl
+++ b/src/Copier.jl
@@ -23,13 +23,14 @@ end
 Wrapper around [copier.run_copy](https://copier.readthedocs.io/en/stable/reference/main/#copier.main.run_copy).
 
 This is an internal function, if BestieTemplate's main API is not sufficient, open an issue.
+Note: this is not `Base.copy`, inside the Copier module we shadow that name.
 """
-function Base.copy(src_path, dst_path, data::Dict = Dict(); kwargs...)
+function copy(src_path, dst_path, data::Dict = Dict(); kwargs...)
   copier = PythonCall.pyimport("copier")
   copier.run_copy(src_path, dst_path, data; kwargs...)
 end
 
-function Base.copy(dst_path, data::Dict = Dict(); kwargs...)
+function copy(dst_path, data::Dict = Dict(); kwargs...)
   copy(joinpath(@__DIR__, ".."), dst_path, data; kwargs...)
 end
 


### PR DESCRIPTION
There was type piracy of `Base.copy`,
because it was overloaded without any of the types belonging to this package.
This can cause spooky action at a distance -- just loading this package changes what `Base.copy` does even if you don't load the module directly.
To be precise it turned what used to be a error into an unexpected behavior. This is misdemeanor type piracy. This is thus very unlikely to have actually caused anyone problems.
But still it is poor code form.

Fortunately the code has already been written to refer to `Copier.copy` in the place it is used.
Which in this case previously resolved to `Base.copy` which was imported by default (check `@which Copier.copy`). And the `Copier` module doesn't use `Base.copy` already, so we can just rmove the `Base.` and it will shadow the name.
Some people find shadowing spooky.
The alternative is to give it a different name. Or pass a type that you own to it.)

## Related issues

There is no related issue.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [ ] Tests are passing
- [ ] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated

(I don't think this needs a changelog entry, since it should be invisible to errors unless they were hitting this very unlikely bug)