### PR TITLE
Change the default indentation from 2 to 4

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -46,6 +46,17 @@ jobs:
           arch: ${{ inputs.arch }}
       - name: Use Julia cache
         uses: julia-actions/cache@v2
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          cache: "pip"
+      - name: Cache pre-commit
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}
+      - name: Install pre-commit
+        run: pip install pre-commit
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning].
 
 - Update pre-commit hook versions
   - JuliaFormatter 1.0.58 -> 1.0.59
+- Default Indentation changed from 2 to 4 (#403)
 
 ## [0.9.1] - 2024-07-24
 

--- a/copier.yml
+++ b/copier.yml
@@ -50,7 +50,7 @@ Indentation:
   type: int
   help: Indentation length (Used in .JuliaFormatter and other configuration files of formatters and linters if you add them)
   validator: "{% if Indentation <= 0 %}Indentation must be positive{% endif %}"
-  default: 2
+  default: 4
 
 # Optional
 AnswerStrategy:

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -25,7 +25,7 @@ const strategy_minimum = merge(
   Dict(
     "JuliaMinVersion" => "1.6",
     "License" => "MIT",
-    "Indentation" => "2",
+    "Indentation" => "4",
     "AnswerStrategy" => "minimum",
   ),
 )

--- a/template/docs/make.jl.jinja
+++ b/template/docs/make.jl.jinja
@@ -6,18 +6,18 @@ DocMeta.setdocmeta!({{ PackageName }}, :DocTestSetup, :(using {{ PackageName }})
 const page_rename = Dict("developer.md" => "Developer docs") # Without the numbers
 
 makedocs(;
-  modules = [{{ PackageName }}],
-  authors = "{{ AuthorName }} <{{ AuthorEmail }}> and contributors",
-  repo = "https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/{commit}{path}#{line}",
-  sitename = "{{ PackageName }}.jl",
-  format = Documenter.HTML(; canonical = "https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl"),
-  pages = [
-    "index.md"
-    [
-      file for
-      file in readdir(joinpath(@__DIR__, "src")) if file != "index.md" && splitext(file)[2] == ".md"
-    ]
-  ],
+    modules = [{{ PackageName }}],
+    authors = "{{ AuthorName }} <{{ AuthorEmail }}> and contributors",
+    repo = "https://github.com/{{ PackageOwner }}/{{ PackageName }}.jl/blob/{commit}{path}#{line}",
+    sitename = "{{ PackageName }}.jl",
+    format = Documenter.HTML(; canonical = "https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl"),
+    pages = [
+        "index.md"
+        [
+            file for file in readdir(joinpath(@__DIR__, "src")) if
+            file != "index.md" && splitext(file)[2] == ".md"
+        ]
+    ],
 )
 
 deploydocs(; repo = "github.com/{{ PackageOwner }}/{{ PackageName }}.jl")

--- a/template/test/runtests.jl.jinja
+++ b/template/test/runtests.jl.jinja
@@ -2,5 +2,5 @@ using {{ PackageName }}
 using Test
 
 @testset "{{ PackageName }}.jl" begin
-  @test {{ PackageName }}.hello_world() == "Hello, World!"
+    @test {{ PackageName }}.hello_world() == "Hello, World!"
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/test-consistency-with-copier-cli.jl
+++ b/test/test-consistency-with-copier-cli.jl
@@ -1,10 +1,14 @@
 @testset "Testing copy, recopy and rebase" begin
   _with_tmp_dir() do dir_copier
     run(`copier copy --vcs-ref HEAD --quiet $(C.args.copier.ask) $(C.template_path) .`)
+    _git_setup()
+    _full_precommit()
 
     @testset "Compare copied project vs copier CLI baseline" begin
       _with_tmp_dir() do dir_bestie
         BestieTemplate.Copier.copy(dir_bestie, C.args.bestie.ask; quiet = true, vcs_ref = "HEAD")
+        _git_setup()
+        _full_precommit()
         _test_diff_dir(dir_bestie, dir_copier)
       end
     end
@@ -21,6 +25,8 @@
           overwrite = true,
           vcs_ref = "HEAD",
         )
+        _git_setup()
+        _full_precommit()
         _test_diff_dir(dir_bestie, dir_copier)
       end
     end
@@ -36,6 +42,8 @@
           quiet = true,
           vcs_ref = "HEAD",
         )
+        _git_setup()
+        _full_precommit()
         _test_diff_dir(dir_bestie, dir_copier)
       end
     end


### PR DESCRIPTION
This is the default in the Julia ecosystem, both in the official guidelines and on various styles.

The Julia files in the template have been changed to use 4 spaces.
The other files in the template are still using 2 spaces.
This should be changed to 4 when pre-commit is run for the first time.

Update the consistency tests that verifies Copier's API to run the
pre-commit before the comparison, to ensure that formatting changes
don't influence the tests.


<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #403


<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
