### PR TITLE
New question: JuliaMinCIVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning].
 - The minimum Julia version is also guessed now (#225)
 - The package owner is also guessed now (#225)
 - The indentation is also guessed now (#225)
+- New question: JuliaMinCIVersion, which defines which Julia version to use in the CI (#400)
 
 ### Changed
 

--- a/copier.yml
+++ b/copier.yml
@@ -1,3 +1,9 @@
+# Constants
+JULIA_LTS_VERSION:
+  when: false
+  type: str
+  default: 1.6
+
 # Essential questions
 PackageName:
   type: str
@@ -34,7 +40,7 @@ AuthorEmail:
 JuliaMinVersion:
   type: str
   help: Minimum Julia version (Used in Project.toml and CI. The suggestion below is the LTS version)
-  default: 1.6
+  default: "{{ JULIA_LTS_VERSION }}"
 
 License:
   type: str
@@ -70,6 +76,12 @@ AddPrecommit:
   help: Pre-commit (Whether to add pre-commit.org. It runs before every commit fixing your formatting and preventing bad practices)
 
 # CI
+JuliaMinCIVersion:
+  when: "{{ AnswerStrategy == 'ask' }}"
+  type: str
+  help: Minimum Julia version used in the tests (lts defaults to the Long Term Support version)
+  default: "{% if JuliaMinVersion == JULIA_LTS_VERSION %}lts{% else %}{{ JuliaMinVersion }}{% endif %}"
+
 AddMacToCI:
   when: "{{ AnswerStrategy == 'ask' }}"
   type: bool

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -36,6 +36,7 @@ const strategy_ask = merge(strategy_recommended, Dict("AnswerStrategy" => "ask")
 
 const optional_questions_with_default = Dict(
   "AddPrecommit" => true,
+  "JuliaMinCIVersion" => "lts",
   "AddMacToCI" => true,
   "AddWinToCI" => true,
   "RunJuliaNightlyOnCI" => true,

--- a/template/.github/workflows/Test.yml.jinja
+++ b/template/.github/workflows/Test.yml.jinja
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "{{ JuliaMinVersion }}"
+          - "{{ JuliaMinCIVersion }}"
           - "1"
         os:
           - ubuntu-latest

--- a/test/test-bad-usage-and-errors.jl
+++ b/test/test-bad-usage-and-errors.jl
@@ -22,6 +22,7 @@ end
     @testset "It works if the dst_path is ." begin
       mkdir("some_folder2")
       cd("some_folder2") do
+        @show readdir(".")
         # Should not throw
         BestieTemplate.generate(
           C.template_path,

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -81,6 +81,7 @@ _random(::Val{:License}, value) = rand(["Apache-2.0", "GPL-3.0", "MIT", "MPL-2.0
 _random(::Val{:Indentation}, value) = rand(2:8)
 _random(::Val{:PackageUUID}, value) = [x in C.hex ? rand(C.hex) : x for x in value] |> join
 _random(::Val{:JuliaMinVersion}, value) = "1.$(rand(0:20))"
+_random(::Val{:JuliaMinCIVersion}, value) = rand() < 0.2 ? "lts" : "1.$(rand(0:20))"
 
 """
 Constants used in the tests


### PR DESCRIPTION
Creates a constant `JULIA_LTS_VERSION` for internal use.
Changes the deafult of `JuliaMinVersion` to use the constant.
Create `JuliaMinCIVersion`. It defaults to `lts` if `JuliaMinVersion` is equal to `JULIA_LTS_VERSION`. Otherwise, if defaults to `JuliaMinVersion`.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #400

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
