### PR TITLE
Add GKSwstype in the docs workflow to prevent GR warnings

### DIFF
--- a/template/.github/workflows/Docs.yml.jinja
+++ b/template/.github/workflows/Docs.yml.jinja
@@ -51,3 +51,4 @@ jobs:
           JULIA_PKG_SERVER: ""
           {% raw %}GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}{% endraw %}
+          GKSwstype: "100" # https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988


### PR DESCRIPTION
This is recommended in the Documenter.jl documentation (v1.7.0).
Although not everyone uses Plots and GR, this should not raise
issues.

Closes #132
