### PR TITLE
New question: AutoIncludeTests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ and this project adheres to [Semantic Versioning].
 - The package owner is also guessed now (#225)
 - The indentation is also guessed now (#225)
 - New question: JuliaMinCIVersion, which defines which Julia version to use in the CI (#400)
+- New question: AutoIncludeTests, that auto-includes all `test-*.jl` files in `runtests.jl` (#261)
 
 ### Changed
 
 - Update pre-commit hook versions
-  - JuliaFormatter 1.0.58 -> 1.0.59
+  - JuliaFormatter 1.0.58 -> 1.0.60
 - Default Indentation changed from 2 to 4 (#403)
 
 ## [0.9.1] - 2024-07-24

--- a/copier.yml
+++ b/copier.yml
@@ -20,6 +20,7 @@
 ---
 _skip_if_exists:
   - "**/*.jl"
+  - "!test/runtests.jl"
   - "!docs/make.jl"
   - "**/Project.toml"
   - .all-contributorsrc

--- a/copier/code-quality.yml
+++ b/copier/code-quality.yml
@@ -3,3 +3,9 @@ AddPrecommit:
   type: bool
   default: "{{ AnswerStrategy != 'minimum' }}"
   help: Pre-commit (Whether to add pre-commit.org. It runs before every commit fixing your formatting and preventing bad practices)
+
+AutoIncludeTests:
+  when: "{{ AnswerStrategy == 'ask' }}"
+  type: bool
+  default: "{{ AnswerStrategy != 'minimum' }}"
+  help: Auto-include test files named `test-<name>.jl` (Incentivizes splitting your tests and better naming them, and helps avoiding forgetting to include the tests manually)

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -36,6 +36,7 @@ const strategy_ask = merge(strategy_recommended, Dict("AnswerStrategy" => "ask")
 
 const optional_questions_with_default = Dict(
   "AddPrecommit" => true,
+  "AutoIncludeTests" => true,
   "JuliaMinCIVersion" => "lts",
   "AddMacToCI" => true,
   "AddWinToCI" => true,

--- a/template/test/runtests.jl.jinja
+++ b/template/test/runtests.jl.jinja
@@ -1,6 +1,27 @@
 using {{ PackageName }}
 using Test
 
+{% if AutoIncludeTests %}
+#=
+Don't add your tests to runtests.jl. Instead, create files named
+
+    test-title-for-my-test.jl
+
+The file will be automatically included inside a `@testset` with title "Title For My Test".
+=#
+for (root, dirs, files) in walkdir(@__DIR__)
+    for file in files
+        if isnothing(match(r"^test-.*\.jl$", file))
+            continue
+        end
+        title = titlecase(replace(splitext(file[6:end])[1], "-" => " "))
+        @testset "$title" begin
+            include(title)
+        end
+    end
+end
+{% else %}
 @testset "{{ PackageName }}.jl" begin
     @test {{ PackageName }}.hello_world() == "Hello, World!"
 end
+{% endif %}

--- a/template/test/{% if AutoIncludeTests %}test-basic-test.jl{% endif %}.jinja
+++ b/template/test/{% if AutoIncludeTests %}test-basic-test.jl{% endif %}.jinja
@@ -1,0 +1,3 @@
+@testset "{{ PackageName }}.jl" begin
+    @test {{ PackageName }}.hello_world() == "Hello, World!"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,10 +24,14 @@ include("utils.jl")
 # Defined in utils.jl to hold constants
 using .C: C
 
-test_files = filter(file -> startswith("test-")(file) && endswith(".jl")(file), readdir(@__DIR__))
-for file in test_files
-  title = splitext(file)[1] |> x -> replace(x, "-" => " ") |> titlecase
-  @testset "$title" begin
-    include(file)
+for (root, dirs, files) in walkdir(@__DIR__)
+  for file in files
+    if isnothing(match(r"^test-.*\.jl$", file))
+      continue
+    end
+    title = titlecase(replace(splitext(file[6:end])[1], "-" => " "))
+    @testset "$title" begin
+      include(file)
+    end
   end
 end


### PR DESCRIPTION
If selected, AutoIncludeTests will add a snippet in runtests.jl that
reads through all test-*.jl files and include them inside a @testset.
Because of this, test/runtests.jl is not ignored anymore.

Closes #261
