### PR TITLE
Add quickstart example usage to module docstring

### DIFF
--- a/src/BestieTemplate.jl
+++ b/src/BestieTemplate.jl
@@ -6,7 +6,7 @@ to use it from Julia.
 
 The main functions are: [`generate`](@ref), [`apply`](@ref), and [`update`](@ref).
 
-To create a new package using BestiTemplate run
+To create a new package using BestieTemplate run
 
 ```julia
 julia> BestieTemplate.generate("path/to/YourNewPackage.jl")

--- a/src/BestieTemplate.jl
+++ b/src/BestieTemplate.jl
@@ -6,6 +6,18 @@ to use it from Julia.
 
 The main functions are: [`generate`](@ref), [`apply`](@ref), and [`update`](@ref).
 
+To create a new package using BestiTemplate run
+
+```julia
+julia> BestieTemplate.generate("path/to/YourNewPackage.jl")
+```
+
+To apply the template to an existing package
+
+```julia
+julia> BestieTemplate.apply("path/to/YourExistingPackage.jl")
+```
+
 Check the documentation: https://abelsiqueira.com/BestieTemplate.jl
 """
 module BestieTemplate


### PR DESCRIPTION
<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

I create new packages rarely enough that I generally don't remeber by heart what command to run. I had the same issue with PkgTemplates.jl and one thing I really liked is that I could do `?PkgTemplate` in the REPL and it would kindly remind me how to use it (to be fair, that was just dumping the Pkg README in the terminal, hence I had to do a bit of scrolling).

This PR adds the quickstart example usage to the module docstring, so that people can do `?BestieTemplate` to get a quick reminder of how to use it.

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
