### PR TITLE
Document deprecation and add test for smooth update

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -40,6 +40,10 @@ jobs:
       - run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
+          git branch this-pr
+          git checkout origin/main
+          git branch --track main origin/main
+          git checkout this-pr
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ inputs.version }}

--- a/docs/src/91-developer.md
+++ b/docs/src/91-developer.md
@@ -317,3 +317,26 @@ Since the GitHub workflow also uses `{` and `}` for their commands, we want to e
 ```jinja
 os: {% raw %}%{{ matrix.os }}{% endraw %}
 ```
+
+## Removing/replacing a question
+
+!!! warn
+    This has only been tested with a single change
+
+Before removing a question, we should deprecate it for one major release.
+We also want to ensure a smooth transition when the user updates.
+
+Luckily, we do have one test that minimally simulates this situation:
+"Test updating from main to HEAD vs generate in HEAD" inside file `test/test-bestie-specific-api`.
+
+This test will run `generate` using the local `main` branch (which won't contain the changes), and run the `update` command, with `defaults=true`, and then compare the result to running `generate` directly.
+
+- Change the `help` field to start with "(Deprecated in VERSION)" (VERSION should be the next major release)
+- Set `when: false` in the question
+- Update the CHANGELOG
+  - Entry in `Deprecated` section
+  - Add or update a "Breaking notice" in the beginning to inform of the changes
+- Move the default questions answers in `src/debug/Data.jl` to the `deprecated` dictionary.
+- Make sure that nothing depends on the old question
+- If necessary, change some `default` values to use the deprecated questions, to ensure a smooth transition.
+- Remove the question in the next release

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -2,7 +2,7 @@
 Fake data for testing
 
 - `Debug.Data`: NamedTuple of Dictionaries with default data
-  - `Debug.Data.minimum_defaults`: Required data if you use `defaults = true`
+  - `Debug.Data.required`: Required data if you use `defaults = true`
   - `Debug.Data.strategy_minimum`: Required data for strategy minimum, no defaults.
   - `Debug.Data.strategy_recommended`: Required data for strategy recommended, no defaults.
   - `Debug.Data.strategy_ask`: Required data for strategy ask, no defaults.
@@ -12,16 +12,21 @@ module Data
 using Random: MersenneTwister
 using UUIDs: uuid4
 
-const minimum_defaults = Dict(
-  "PackageName" => "FakePkg",
-  "PackageUUID" => string(uuid4(MersenneTwister(123))),
-  "PackageOwner" => "bestietemplate",
-  "AuthorName" => "Bestie Template",
-  "AuthorEmail" => "bestie@fake.nl",
+const deprecated = Dict()
+
+const required = merge(
+  Dict(
+    "PackageName" => "FakePkg",
+    "PackageUUID" => string(uuid4(MersenneTwister(123))),
+    "PackageOwner" => "bestietemplate",
+    "AuthorName" => "Bestie Template",
+    "AuthorEmail" => "bestie@fake.nl",
+  ),
+  deprecated,
 )
 
 const strategy_minimum = merge(
-  minimum_defaults,
+  required,
   Dict(
     "JuliaMinVersion" => "1.6",
     "License" => "MIT",

--- a/test/test-bad-usage-and-errors.jl
+++ b/test/test-bad-usage-and-errors.jl
@@ -22,7 +22,6 @@ end
     @testset "It works if the dst_path is ." begin
       mkdir("some_folder2")
       cd("some_folder2") do
-        @show readdir(".")
         # Should not throw
         BestieTemplate.generate(
           C.template_path,

--- a/test/test-bestie-specific-api.jl
+++ b/test/test-bestie-specific-api.jl
@@ -204,3 +204,42 @@ end
     end
   end
 end
+
+@testset "Test updating from main to HEAD vs generate in HEAD" begin
+  _with_tmp_dir() do dir
+    common_args = (defaults = true, quiet = true)
+
+    mkdir("gen_then_up")
+    cd("gen_then_up") do
+      # Generate the release version
+      BestieTemplate.generate(
+        C.template_path,
+        ".",
+        C.args.bestie.req;
+        vcs_ref = "main",
+        common_args...,
+      )
+      _git_setup()
+      _full_precommit()
+      # Update using the HEAD version
+      BestieTemplate.update(".", C.args.bestie.req; vcs_ref = "HEAD", common_args...)
+      _full_precommit()
+    end
+
+    mkdir("gen_direct")
+    cd("gen_direct") do
+      # Generate directly in the HEAD version
+      BestieTemplate.generate(
+        C.template_path,
+        ".",
+        C.args.bestie.req;
+        vcs_ref = "HEAD",
+        common_args...,
+      )
+      _git_setup()
+      _full_precommit()
+    end
+
+    _test_diff_dir("gen_then_up", "gen_direct")
+  end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -60,6 +60,9 @@ function _test_diff_dir(dir1, dir2)
       end
 
       @testset "File $(nice_dir(file))" for file in files
+        if endswith(".rej")(file)
+          continue
+        end
         file1 = joinpath(root, file)
         file2 = replace(file1, dir1 => dir2)
         lines1 = readlines(file1)
@@ -94,7 +97,7 @@ using BestieTemplate.Debug.Data: Data
 _bestie_args_to_copier_args(dict) = vcat([["-d"; "$k=$v"] for (k, v) in dict]...)
 
 "Arguments for the different calls"
-_bestie_args = (min = Data.strategy_minimum, ask = Data.strategy_ask_default)
+_bestie_args = (req = Data.required, min = Data.strategy_minimum, ask = Data.strategy_ask_default)
 args = (
   bestie = _bestie_args,
   copier = NamedTuple(


### PR DESCRIPTION
Test that when you generate a package in the previous main
and then update to the HEAD using only the required data
and defaults, that it is the same as generating the package
in the HEAD.

Warning: the interactions with other changes is not clear yet.

Closes #428

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
