### PR TITLE
Don't create main branch when on main and don't run some tests on main

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -40,6 +40,9 @@ jobs:
       - run: |
           git config --global user.email "action@github.com"
           git config --global user.name "GitHub Action"
+      - name: Create branch main
+        if: github.ref != 'refs/heads/main'
+        run: |
           git branch this-pr
           git checkout origin/main
           git branch --track main origin/main

--- a/test/test-bestie-specific-api.jl
+++ b/test/test-bestie-specific-api.jl
@@ -205,41 +205,43 @@ end
   end
 end
 
-@testset "Test updating from main to HEAD vs generate in HEAD" begin
-  _with_tmp_dir() do dir
-    common_args = (defaults = true, quiet = true)
+if read(`git branch --show-current`, String) != "main"
+  @testset "Test updating from main to HEAD vs generate in HEAD" begin
+    _with_tmp_dir() do dir
+      common_args = (defaults = true, quiet = true)
 
-    mkdir("gen_then_up")
-    cd("gen_then_up") do
-      # Generate the release version
-      BestieTemplate.generate(
-        C.template_path,
-        ".",
-        C.args.bestie.req;
-        vcs_ref = "main",
-        common_args...,
-      )
-      _git_setup()
-      _full_precommit()
-      # Update using the HEAD version
-      BestieTemplate.update(".", C.args.bestie.req; vcs_ref = "HEAD", common_args...)
-      _full_precommit()
+      mkdir("gen_then_up")
+      cd("gen_then_up") do
+        # Generate the release version
+        BestieTemplate.generate(
+          C.template_path,
+          ".",
+          C.args.bestie.req;
+          vcs_ref = "main",
+          common_args...,
+        )
+        _git_setup()
+        _full_precommit()
+        # Update using the HEAD version
+        BestieTemplate.update(".", C.args.bestie.req; vcs_ref = "HEAD", common_args...)
+        _full_precommit()
+      end
+
+      mkdir("gen_direct")
+      cd("gen_direct") do
+        # Generate directly in the HEAD version
+        BestieTemplate.generate(
+          C.template_path,
+          ".",
+          C.args.bestie.req;
+          vcs_ref = "HEAD",
+          common_args...,
+        )
+        _git_setup()
+        _full_precommit()
+      end
+
+      _test_diff_dir("gen_then_up", "gen_direct")
     end
-
-    mkdir("gen_direct")
-    cd("gen_direct") do
-      # Generate directly in the HEAD version
-      BestieTemplate.generate(
-        C.template_path,
-        ".",
-        C.args.bestie.req;
-        vcs_ref = "HEAD",
-        common_args...,
-      )
-      _git_setup()
-      _full_precommit()
-    end
-
-    _test_diff_dir("gen_then_up", "gen_direct")
   end
 end


### PR DESCRIPTION
The ReusableTest workflow creates a main branch due a specific
test recently introduced. That specific runs the generation on main
and on HEAD.
Both activites make no sense if we are running on the main branch,
This creates a condition on the workflow to only run if the
branch is not main (a condition on PRs would also work, but we
leave the possibility of running tests on others branches with
this approach). Furthermore, this also adds a condition in the tests
such that only on main the tests are run.

Closes #435
