### PR TITLE
Use min for julia-setup

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"
+          - "lts"
           - "1"
         os:
           - ubuntu-latest

--- a/.github/workflows/TestGeneratedPkg.yml
+++ b/.github/workflows/TestGeneratedPkg.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - "1.6"
+          - "lts"
           - "1"
         os:
           - ubuntu-latest

--- a/copier/ci.yml
+++ b/copier/ci.yml
@@ -1,11 +1,12 @@
 JuliaMinCIVersion:
   when: "{{ AnswerStrategy == 'ask' }}"
   type: str
-  help: Minimum Julia version used in the tests (lts defaults to the Long Term Support version)
+  help: Minimum Julia version used in the tests (min, lts, or a version. See https://github.com/julia-actions/setup-julia#examples for accepted values)
   default: "{% if JuliaMinVersion == JULIA_LTS_VERSION %}lts{% else %}{{ JuliaMinVersion }}{% endif %}"
   description: |
     The Test workflow runs two versions of Julia by default: the latest stable release, which is defined by "1", and this version.
     It defaults to either "lts", or the version that you answered in JuliaMinVersion, if it wasn't the LTS.
+    Also accepts "min", which defaults to the minimum supported version in the compat section of Project.toml, or a version specification. See https://github.com/julia-actions/setup-julia#examples for more options.
 
 AddMacToCI:
   when: "{{ AnswerStrategy == 'ask' }}"


### PR DESCRIPTION
In the package, use lts instead of 1.6 for Test.yml and TestGeneratedPkg.yml.
For the template, change the JuliaMinCIVersion description to mention "min".

Originally planned to use "min", but it chooses to use 1.6.0.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #415

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
