### PR TITLE
TestGeneratedPkg with the HEAD version of the template

### DIFF
--- a/.github/workflows/TestGeneratedPkg.yml
+++ b/.github/workflows/TestGeneratedPkg.yml
@@ -73,10 +73,16 @@ jobs:
               "PackageName" => "Guldasta",
               "PackageUUID" => string(UUIDs.uuid4()),
               "PackageOwner" => "Bagicha",
-              "AuthorName" => "Mali",
-              "AuthorEmail" => "mali@bagicha.site"
+              "Authors" => "Mali <mali@bagicha.site>"
             );
-            BestieTemplate.generate("tmp/Guldasta.jl", data; defaults = true, quiet = true);
+            BestieTemplate.generate(
+              pkgdir(BestieTemplate),
+              "tmp/Guldasta.jl",
+              data;
+              defaults = true,
+              quiet = true,
+              vcs_ref="HEAD"
+            );
           '
       - name: Run the tests in the generated package
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning].
 ### Fixed
 
 - The TestGeneratedPkg workflow now runs the latest unreleased version of the pkg (#450)
+- The tests of the generated package correctly include the `test-*.jl` files (#452)
 
 ## [0.10.0] - 2024-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- The TestGeneratedPkg workflow now runs the latest unreleased version of the pkg (#450)
+
 ## [0.10.0] - 2024-09-10
 
 Breaking notice:

--- a/template/test/runtests.jl.jinja
+++ b/template/test/runtests.jl.jinja
@@ -16,7 +16,7 @@ for (root, dirs, files) in walkdir(@__DIR__)
         end
         title = titlecase(replace(splitext(file[6:end])[1], "-" => " "))
         @testset "$title" begin
-            include(title)
+            include(file)
         end
     end
 end


### PR DESCRIPTION
Fix bug where TestGeneratedPkg was running with the release
version of the package, which invalidated the idea of the
test in the first place.

Closes #450
