### PR TITLE
Don't run update tests on releases

### DIFF
--- a/test/test-bestie-specific-api.jl
+++ b/test/test-bestie-specific-api.jl
@@ -189,7 +189,9 @@ end
   end
 end
 
-if chomp(read(`git branch --show-current`, String)) != "main"
+# Don't run for branch main or releases
+if chomp(read(`git branch --show-current`, String)) != "main" &&
+   get(ENV, "GITHUB_EVENT_NAME", "nothing") != "release"
   @testset "Test updating from main to HEAD vs generate in HEAD" begin
     _with_tmp_dir() do dir
       common_args = (defaults = true, quiet = true)


### PR DESCRIPTION
The update tests try to compare two versions of the generated
package. Since the release is done form the main branch, this
test can't run properly.
This PR checks if the GitHub CI event is release, and don't
run the test if it is.

Can only be properly tested with a new release.

Related to #454
