### PR TITLE
Add first command in Next Steps: exit() to exit Julia REPL

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -89,6 +89,7 @@ function generate(src_path, dst_path, data::Dict = Dict(); kwargs...)
 
   Next steps: Create git repository and push to Github.
 
+  \$ exit()                # Exit the Julia REPL
   \$ cd $dst_path
   \$ git init
   \$ git add .
@@ -180,6 +181,7 @@ function apply(
       Review the modifications.
       In particular README.md and docs/src/index.md tend to be heavily edited.
 
+      \$ exit() # Exit the Julia REPL
       \$ git switch -c apply-bestie # If you haven't created a branch
       \$ git add .
       \$ pre-commit run -a # Try to fix possible pre-commit issues (failures are expected)


### PR DESCRIPTION
<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->
## Description
Minor addition to the message displayed 'Next steps' afteer generating using BestieTemplate or applying BestieTemplate to an existing package.
As explained in #463 I copy paste the instructions, but first one needs to exit the Julia REPL and execute the following commands in terminal.

I did not update the **documentation** (i.e. full guide) because I think it would be cumbersome and not necessary as what gets print in the terminal, but I am open to suggestions if you feel that we should update that too.

Same for **CHANGELOG.md**, I feel this is a very small change, but will added if is useful.

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #463 

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)

- [x] Tests are passing
- [x] Lint workflow is passing
- [ ] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
