### PR TITLE
Declare generate, apply and update as public

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -24,6 +24,7 @@ jobs:
         version:
           - "lts"
           - "1"
+          - "pre"
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Abel Soares Siqueira <abel.s.siqueira@gmail.com> and contributors"]
 version = "0.10.1"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
@@ -13,6 +14,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
+Compat = "3.47, 4.10"
 CondaPkg = "0.2"
 Markdown = "1.6"
 PythonCall = "0.9"

--- a/src/BestieTemplate.jl
+++ b/src/BestieTemplate.jl
@@ -22,6 +22,7 @@ Check the documentation: https://abelsiqueira.com/BestieTemplate.jl
 """
 module BestieTemplate
 
+using Compat: @compat
 using Markdown: @md_str
 using TOML: TOML
 using YAML: YAML

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,3 +1,5 @@
+@compat public generate, apply, update
+
 """
     _copy(src_path, dst_path, data; kwargs...)
 


### PR DESCRIPTION
Mark generate, apply and update as public using the public API.
They were already intended to be public by the definition of "documented and
not prepended by `-`" (as opposed to `_copy`, for instance).
Also use the change to add "pre" to the Test workflow.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.

Make sure to read the contributing guidelines and abide by the code of conduct.

See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #473

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->

- [x] I am following the [contributing guidelines](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/abelsiqueira/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
