### PR TITLE
Add write permissions for documentation job

### DIFF
--- a/.github/workflows/Docs.yml
+++ b/.github/workflows/Docs.yml
@@ -28,6 +28,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
This will ensure the action has sufficient permissions to create the `gh-pages` branch when it is first triggered.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->

There is no related issue.


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [ ] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
