### PR TITLE
New question and replacements related to dependabot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,34 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+BREAKING NOTICE:
+
+- The questions `AddDependabot` and `AddCompatHelperCI` have been removed in favour of
+`GitHubActionVersionAutoUpdate` and `JuliaCompatAutoUpdate`. Since dependabot now officially supports Julia (<https://github.blog/changelog/2025-12-16-dependabot-version-updates-now-support-julia/>), the default suggestions for managing Julia compat updates is dependabot. The equivalence is the following:
+  - `AddDependabot = false` -> `GitHubActionVersionAutoUpdate = 'none'`
+  - `AddDependabot = true` -> `GitHubActionVersionAutoUpdate = 'dependabot'`
+  - `AddCompatHelperCI = false` -> `JuliaCompatAutoUpdate = 'none'`
+  - `AddCompatHelperCI = true` -> `JuliaCompatAutoUpdate = 'compathelper'`
+  When using defaults, the results are as follow:
+  - For the "Tiny" strategy, both are unselected
+  - For the "Light" strategy, dependabot is used for Julia compat updates
+  - For other strategies, dependabot is used for both Julia compat and GitHub actions updates.
+
+### Added
+
+- New question: `GitHubActionVersionAutoUpdate`, to control whether to use dependabot to automatically update GitHub action versions (#561)
+- New question: `JuliaCompatAutoUpdate`, to control whether to use dependabot or CompatHelper to automatically update Julia compat versions (#561)
+
 ### Changed
 
 - Update action `actions/checkout` version to 6 (#567)
 - Update action `actions/cache` version to 5 (#571)
 - Update action `peter-evans/create-pull-request` version to 8 (#570)
+
+### Removed
+
+- The question `AddDependabot` is not asked anymore. Instead, it is now implicitly defined by `GitHubActionVersionAutoUpdate` and `JuliaCompatAutoUpdate` (#561)
+- The question `AddCompatHelperCI` is not asked anymore. Instead, it is now implicitly defined by `JuliaCompatAutoUpdate` (#561)
 
 ## [0.17.1] - 2025-12-19
 

--- a/copier/ci.yml
+++ b/copier/ci.yml
@@ -21,10 +21,9 @@ AddDocsCI:
     Strategy: Light
 
 AddCompatHelperCI:
-  when: "{{ WhenForLight }}"
+  when: false
   type: bool
-  default: "{{ DefaultForLight }}"
-  help: Add CompatHelper workflow (Add CompatHelper.yml to automatically update the compat section of Project.toml)
+  default: "{{ JuliaCompatAutoUpdate == 'compathelper' }}"
   description: |
     Whether to add the CompatHelper.yml workflow that runs periodically to
     automatically update the compat section of the Project.toml file.

--- a/copier/code-quality.yml
+++ b/copier/code-quality.yml
@@ -34,7 +34,7 @@ AddPrecommit:
 TestingStrategy:
   when: "{{ WhenForLight }}"
   type: str
-  default: "{% if DefaultForLight %}testitem_basic{% else %}basic{% endif %}"
+  default: "{% if StrategyLevel > 0 %}testitem_basic{% else %}basic{% endif %}"
   choices:
     Basic @testset approach with single test file: basic
     TestItems with full CLI runner and filtering: testitem_cli
@@ -154,17 +154,45 @@ ExplicitImportsChecklist:
 
     Strategy: Advanced
 
-AddDependabot:
+GitHubActionVersionAutoUpdate:
   when: "{{ WhenForModerate }}"
-  type: bool
-  default: "{{ DefaultForModerate }}"
-  help: Add Dependabot (Whether to add dependabot.yml, which runs periodically to update your GitHub actions versions)
+  type: str
+  default: "{% if StrategyLevel > 1 %}dependabot{% else %}none{% endif %}"
+  help: Autoupdate GitHub Actions versions? (periodically receive PRs updating your workflows)
+  choices:
+    Don't update automatically: none
+    Dependabot: dependabot
   description: |
-    Adds dependabot.yml (https://docs.github.com/en/code-security/dependabot),
-    which runs on GitHub repos periodically to make automated updates to your
-    GitHub actions.
+    Automatically receive updates to versions of GitHub actions.
+
+    "Dependabot" adds `.github/dependabot.yml`.
 
     Strategy: Moderate
+
+JuliaCompatAutoUpdate:
+  when: "{{ WhenForLight }}"
+  type: str
+  default: "{% if StrategyLevel > 0 %}dependabot{% else %}none{% endif %}"
+  help: Autoupdate Project.toml compat? (periodically receive PRs updating your compat sections)
+  choices:
+    Don't update automatically: none
+    Dependabot: dependabot
+    CompatHelper: compathelper
+  description: |
+    Automatically receive updates to Julia's Project.toml compat section.
+
+    "Dependabot" adds `.github/dependabot.yml`. They officially support Julia since 16/Dec/2025
+    (https://github.blog/changelog/2025-12-16-dependabot-version-updates-now-support-julia/).
+
+    "CompatHelper" adds `.github/workflows/CompatHelper.yml`. This is a
+    traditional approach in the Julia community.
+
+    Strategy: Moderate
+
+AddDependabot:
+  when: false
+  type: bool
+  default: "{{ GitHubActionVersionAutoUpdate == 'dependabot' or JuliaCompatAutoUpdate == 'dependabot' }}"
 
 AddLychee:
   when: "{{ WhenForLight }}"

--- a/docs/src/20-explanation.md
+++ b/docs/src/20-explanation.md
@@ -231,7 +231,7 @@ Most workflows are added in the "Light" strategy, but each strategy will have ad
 
 We have a few workflows, with plans to expand in the future:
 
-- `CompatHelper.yml`: Should be well known by now. It checks that your Project.toml compat entries are up-to-date.
+- `CompatHelper.yml`: Should be well known by now. It checks that your Project.toml compat entries are up-to-date. (Note: Dependabot now supports Julia and can replace CompatHelper. Both options are available in the template).
 - `Copier.yml`: This will periodically check the template for updates. If there are updates, this action creates a pull request updating your repo.
 - `Docs.yml`: Build the docs. Only runs when relevant files change.
 - `Lint.yml`: Run the linter and formatter through the command `pre-commit run -a`.

--- a/src/debug/Data.jl
+++ b/src/debug/Data.jl
@@ -23,6 +23,8 @@ const strategies = let
     deprecated,
     Dict(
       "Authors" => "Bestie Template <bestie@fake.nl> and contributors",
+      "GitHubActionVersionAutoUpdate" => "none",
+      "JuliaCompatAutoUpdate" => "none",
       "JuliaMinCIVersion" => "lts",
       "JuliaMinVersion" => "1.10",
       "License" => "MIT",
@@ -40,7 +42,6 @@ const strategies = let
   light = merge(
     tiny,
     Dict(
-      "AddCompatHelperCI" => true,
       "AddDocs" => true,
       "AddDocsCI" => true,
       "AddFormatterAndLinterConfigFiles" => true,
@@ -49,6 +50,7 @@ const strategies = let
       "AddTagBotCI" => true,
       "AddTestCI" => true,
       "ConfigIndentation" => 2,
+      "JuliaCompatAutoUpdate" => "dependabot",
       "JuliaIndentation" => 4,
       "MarkdownIndentation" => 2,
       "StrategyLevel" => 1,
@@ -60,8 +62,8 @@ const strategies = let
     light,
     Dict(
       "AddCitationCFF" => true,
-      "AddDependabot" => true,
       "AddLintCI" => true,
+      "GitHubActionVersionAutoUpdate" => "dependabot",
       "StrategyLevel" => 2,
     ),
   )

--- a/template/{% if AddDotGitHubFolder %}.github{% endif %}/{% if AddDependabot %}dependabot.yml{% endif %}.jinja
+++ b/template/{% if AddDotGitHubFolder %}.github{% endif %}/{% if AddDependabot %}dependabot.yml{% endif %}.jinja
@@ -1,7 +1,18 @@
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 version: 2
 updates:
+{%- if GitHubActionVersionAutoUpdate == 'dependabot' %}
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+{%- endif %}
+{%- if JuliaCompatAutoUpdate == 'dependabot' %}
+  - package-ecosystem: "julia"
+    directories:
+      - "/"
+      - "/docs"
+      - "/test"
+    schedule:
+      interval: "weekly"
+{% endif %}

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -189,6 +189,8 @@ end
   _random(::Val{:StrategyReviewExcluded}, value::Bool) = true
   _random(::Val{:TestingStrategy}, value) =
     rand(["basic", "testitem_cli", "testitem_basic", "basic_auto_discover"])
+  _random(::Val{:GitHubActionVersionAutoUpdate}, value) = rand(["none", "dependabot"])
+  _random(::Val{:JuliaCompatAutoUpdate}, value) = rand(["none", "dependabot", "compathelper"])
 
   # === DATA CREATION UTILITIES ===
   """


### PR DESCRIPTION
Create new questions JuliaCompatAutoUpdate and GitHubActionVersionAutoUpdate.
Make AddDependabot a consequence of either one of these being set to
'dependabot'.
Make AddCompatHelperCI a consequence of JuliaCompatAutoUpdate being
set to 'compathelper'.
Changes defaults to recommend Dependabot instead of CompatHelper as
default option for maintaining Julia compat versions.

<!--
Thanks for making a pull request to BestieTemplate.jl.
We have added this PR template to help you help us.
Make sure to read the contributing guidelines and abide by the code of conduct.
See the comments below, fill the required fields, and check the items.
-->

## Related issues

<!-- We normally work with (i) create issue; (ii) discussion if necessary; (iii) create PR. So, at least one of the following should be true:-->

<!-- Option 1, this closes an existing issue. Fill the number below-->
Closes #561

<!-- Option 2, this is a small fix that arguably won't need an issue. Uncomment below -->
<!--
There is no related issue.
-->

## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [x] I am following the [contributing guidelines](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/docs/src/90-contributing.md)
- [x] Tests are passing
- [x] Lint workflow is passing
- [x] Docs were updated and workflow is passing
- [x] [CHANGELOG.md](https://github.com/JuliaBesties/BestieTemplate.jl/blob/main/CHANGELOG.md) was updated
