### PR TITLE
Fixed new_pkg_quick default behaviour and warns when using local without a .git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- `new_pkg_quick` defaults to using `:online` as template_source (#589)
+
 ## [0.18.2] - 2026-01-06
 
 ### Fixed

--- a/src/friendly.jl
+++ b/src/friendly.jl
@@ -10,7 +10,8 @@ const JULIA_LTS_VERSION = "1.10"
         strategy::Symbol,
         extra_data = Dict();
         license = "MIT",
-        template_source = :local,
+        local_template_path = pkgdir(BestieTemplate),
+        template_source = :online,
         use_latest = false,
         kwargs...;
     )
@@ -37,7 +38,8 @@ generate a package using the "Tiny" strategy.
 ## Keyword arguments
 
 - `license`: Which license to add. Default: `MIT`. Choices: `"Apache-2.0"`, `"GPL-3.0"`, `"MIT"`, `"MPL-2.0"`, `"nothing"`.
-- `template_source::Symbol`: Source of the template, either `:local` or `:online`. `:local` uses the path of the BestieTemplate package, and `:online` uses the GitHub URL. Default: `:local`.
+- `local_template_path`: Template path to use when `template_source = :local`. Default: `pkgdir(BestieTemplate)`
+- `template_source::Symbol`: Source of the template, either `:local` or `:online`. `:local` uses the path of the BestieTemplate package as given by the keyword `local_template_path`, and `:online` uses the GitHub URL. Notice that using `:local` will freeze the version to a folder, so manual update is necessary. Default: `:online`.
 - `use_latest::Bool`: Whether to use the latest commit of the template
   (otherwise use the last release). Default: `false`.
 - Additional keyword arguments are passed directly to `generate`.
@@ -49,7 +51,8 @@ function new_pkg_quick(
   strategy::Symbol,
   extra_data = Dict();
   license = "MIT",
-  template_source::Symbol = :local,
+  local_template_path = pkgdir(BestieTemplate),
+  template_source::Symbol = :online,
   use_latest::Bool = false,
   kwargs...,
 )
@@ -63,7 +66,10 @@ function new_pkg_quick(
   # Ensure valid template source
   template_path = if template_source == :local
     change_permissions = true
-    pkgdir(BestieTemplate)
+    if !isdir(joinpath(local_template_path, ".git"))
+      @warn "Local path $local_template_path is not tracked with .git, updates won't be possible without manual intervention"
+    end
+    local_template_path
   elseif template_source == :online
     "https://github.com/JuliaBesties/BestieTemplate.jl"
   else

--- a/test/test-new-pkg-quick-update.jl
+++ b/test/test-new-pkg-quick-update.jl
@@ -1,0 +1,47 @@
+@testitem "Using new_pkg_quick with :local" tags = [:unit, :fast] setup = [Common] begin
+  using Logging
+
+  test_pkg_name = "NewPkg.jl"
+  test_owner = "JuliaBesties"
+  test_authors = "JuliaBesties maintainers"
+
+  # Default behaviour is to have no warning
+  _with_tmp_dir() do dir
+    @test_logs min_level = Logging.Warn BestieTemplate.new_pkg_quick(
+      test_pkg_name,
+      test_owner,
+      test_authors,
+      :tiny,
+    )
+  end
+
+  # If using `:local` but the `pkgdir` has a `.git` folder, nothing happens
+  _with_tmp_dir() do dir
+    @test_logs min_level = Logging.Warn BestieTemplate.new_pkg_quick(
+      test_pkg_name,
+      test_owner,
+      test_authors,
+      :tiny,
+      template_source = :local,
+    )
+  end
+
+  # If using `:local` and the `pkgdir` has no `.git` folder, then warns
+  _with_tmp_dir() do dir
+    # Creating a copy of BestieTemplate without the .git folder:
+    run(`git clone $(pkgdir(BestieTemplate)) BestieTemplateCopy`)
+    run(`rm -rf ./BestieTemplateCopy/.git`)
+
+    @test_logs (
+      :warn,
+      "Local path BestieTemplateCopy is not tracked with .git, updates won't be possible without manual intervention",
+    ) BestieTemplate.new_pkg_quick(
+      test_pkg_name,
+      test_owner,
+      test_authors,
+      :tiny,
+      local_template_path = "BestieTemplateCopy",
+      template_source = :local,
+    )
+  end
+end


### PR DESCRIPTION
Closes #589
