### PR TITLE
Add eScience Center's blog to the ignore section of lychee and test on generated package

### DIFF
--- a/.github/workflows/ReusableTestGeneratedPkg.yml
+++ b/.github/workflows/ReusableTestGeneratedPkg.yml
@@ -25,6 +25,10 @@ on:
         required: false
         type: boolean
         default: true
+      run_link_checker:
+        required: false
+        type: boolean
+        default: true
       allow_failure:
         required: false
         type: boolean
@@ -38,6 +42,7 @@ jobs:
     env:
       NEEDS_PRECOMMIT: ${{ inputs.strategy_level == 'moderate' || inputs.strategy_level == 'robust' }}
       NEEDS_DOCS: ${{ inputs.enable_docs && inputs.strategy_level != 'tiny' }}
+      NEEDS_LYCHEE: ${{ inputs.run_link_checker && inputs.strategy_level != 'tiny' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -158,3 +163,16 @@ jobs:
           SKIP=no-commit-to-branch pre-commit run -a || true
           # There shouldn't be any more failures after the initial fix
           SKIP=no-commit-to-branch pre-commit run -a
+
+      - name: Fix tmp/Guldasta.jl/.lychee.toml
+        if: ${{ env.NEEDS_LYCHEE == 'true' }}
+        run: |
+          sed -i 's/@ref",/@ref", "agicha",/g' tmp/Guldasta.jl/.lychee.toml
+
+      - name: Check that all links are correct
+        if: ${{ env.NEEDS_LYCHEE == 'true' }}
+        uses: lycheeverse/lychee-action@v2
+        with:
+          fail: true
+          args: --config '.lychee.toml' .
+          workingDirectory: tmp/Guldasta.jl

--- a/.github/workflows/TestGeneratedPkg.yml
+++ b/.github/workflows/TestGeneratedPkg.yml
@@ -45,6 +45,7 @@ jobs:
       arch: ${{ matrix.arch }}
       strategy_level: ${{ matrix.strategy_level }}
       enable_docs: true
+      run_link_checker: true
       allow_failure: ${{ matrix.allow_failure }}
 
   test-testing-strategies:
@@ -70,6 +71,7 @@ jobs:
       strategy_level: "moderate"
       testing_strategy: ${{ matrix.testing_strategy }}
       enable_docs: false
+      run_link_checker: false
 
   test-key-interactions:
     strategy:
@@ -93,3 +95,4 @@ jobs:
       strategy_level: ${{ matrix.combination.strategy_level }}
       testing_strategy: ${{ matrix.combination.testing_strategy }}
       enable_docs: false
+      run_link_checker: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Add eScience Center's blog website to the lychee ignore section (#556)
+
 ## [0.18.3] - 2026-01-10
 
 ### Fixed

--- a/template/{% if AddLychee %}.lychee.toml{% endif %}.jinja
+++ b/template/{% if AddLychee %}.lychee.toml{% endif %}.jinja
@@ -4,6 +4,7 @@ exclude = [
   "^https://github.com/.*/releases/tag/v.*$",
   "^https://doi.org/FIXME$",
   "^https://{{ PackageOwner }}.github.io/{{ PackageName }}.jl/stable$",
+{% if AddContributionDocs %}  "^https://blog.esciencecenter.nl", # due to a certificate error (cf. #556){% endif %}
   "zenodo.org/badge/DOI/FIXME$"
 ]
 


### PR DESCRIPTION
Due to a certificate error, the eScience Center's blog causes lychee
to fail. This ignores it.
Add a link checker step to the testing of generated packages.

Closes #556
