### PR TITLE
Ignore Copier's temp clone cleanup race and fix pkg> test env selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+### Fixed
+
+- Intermittent `OSError: [Errno 39] Directory not empty` no longer fails `generate`, `apply`, `update`, and `add_feature`; the error comes from Copier removing its temporary clone after the files were already created, so it is now safely ignored
+
 ## [0.18.6] - 2026-04-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ Julia wrapper around Python Copier template engine for generating Julia package 
 **Filtered Testing**: `julia --project=test test/runtests.jl --tags fast --exclude slow`
 **Linting**: `pre-commit run -a` (setup: `pre-commit install`)
 
+When on `main`, the `no-commit-to-branch` hook fails and `fail_fast: true` aborts all later hooks, so the lint checks silently don't run. Prefix with `SKIP` to run the real checks: `SKIP=no-commit-to-branch pre-commit run --files <changed files>`
+
 ### Testing via julia-mcp
 
 When julia-mcp is available, prefer it over CLI. The Julia session stays alive between calls, avoiding recompilation.

--- a/src/Copier.jl
+++ b/src/Copier.jl
@@ -17,6 +17,53 @@ function __init__()
 end
 
 """
+    _copier_tempdir_from_exception(ex)
+
+If `ex` is Copier failing to remove its own temporary VCS clone, return the path of
+that temporary clone. Otherwise, return `nothing`.
+"""
+function _copier_tempdir_from_exception(ex)
+  isa(ex, PythonCall.PyException) || return nothing
+  PythonCall.pyisinstance(ex.v, PythonCall.pybuiltins.OSError) || return nothing
+  filename = PythonCall.pyconvert(Any, ex.v.filename)
+  filename isa AbstractString || return nothing
+  parts = splitpath(filename)
+  i = findfirst(startswith("copier._vcs.clone."), parts)
+  isnothing(i) && return nothing
+  return joinpath(parts[1:i]...)
+end
+
+"""
+    _ignore_cleanup_race(f)
+
+Run `f()`, ignoring failures from Copier's cleanup of its temporary VCS clone.
+
+Copier removes its temporary clone only after the requested operation has fully
+completed, and on Linux that `shutil.rmtree` intermittently fails with
+`OSError: [Errno 39] Directory not empty`. The destination files are already in
+place at that point, so the operation is treated as successful and the leftover
+temporary clone is removed here instead.
+"""
+function _ignore_cleanup_race(f)
+  try
+    f()
+  catch ex
+    copier_tempdir = _copier_tempdir_from_exception(ex)
+    isnothing(copier_tempdir) && rethrow()
+    @debug "Ignoring failure to remove Copier's temporary clone" copier_tempdir
+    for _ in 1:3
+      try
+        rm(copier_tempdir; recursive = true, force = true)
+        break
+      catch
+        sleep(0.1)
+      end
+    end
+    nothing
+  end
+end
+
+"""
     copy(dst_path[, data]; kwargs...)
     copy(src_path, dst_path[, data]; kwargs...)
 
@@ -27,7 +74,9 @@ Note: this is not `Base.copy`, inside the Copier module we shadow that name.
 """
 function copy(src_path, dst_path, data::Dict = Dict(); kwargs...)
   copier = PythonCall.pyimport("copier")
-  copier.run_copy(src_path, dst_path, data; kwargs...)
+  _ignore_cleanup_race() do
+    copier.run_copy(src_path, dst_path, data; kwargs...)
+  end
 end
 
 function copy(dst_path, data::Dict = Dict(); kwargs...)
@@ -43,7 +92,9 @@ This is an internal function, if BestieTemplate's main API is not sufficient, op
 """
 function recopy(dst_path, data::Dict = Dict(); kwargs...)
   copier = PythonCall.pyimport("copier")
-  copier.run_recopy(dst_path; data = data, kwargs...)
+  _ignore_cleanup_race() do
+    copier.run_recopy(dst_path; data = data, kwargs...)
+  end
 end
 
 """
@@ -55,7 +106,9 @@ This is an internal function, if BestieTemplate's main API is not sufficient, op
 """
 function update(dst_path, data::Dict = Dict(); kwargs...)
   copier = PythonCall.pyimport("copier")
-  copier.run_update(dst_path, data; kwargs...)
+  _ignore_cleanup_race() do
+    copier.run_update(dst_path, data; kwargs...)
+  end
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,15 @@
 #!/usr/bin/env julia
 
+# Must be set before CondaPkg resolves (triggered when the first testitem loads
+# BestieTemplate). The same setup in the `Common` testsnippet runs too late under
+# `pkg> test`, which would silently build a second env at test/.CondaPkg.
+if get(ENV, "CI", "nothing") == "nothing"
+  ENV["JULIA_CONDAPKG_ENV"] = joinpath(@__DIR__, "conda-env")
+  if isdir(ENV["JULIA_CONDAPKG_ENV"])
+    ENV["JULIA_CONDAPKG_OFFLINE"] = true
+  end
+end
+
 using Pkg
 using TestItemRunner
 using TOML
@@ -231,10 +241,9 @@ function parse_arguments()
     return tag
   end
 
-  tag_transform(list_of_tags) =
-    map(split(list_of_tags, ",")) do tag
-      ensure_tag_existence(Symbol(tag))
-    end
+  tag_transform(list_of_tags) = map(split(list_of_tags, ",")) do tag
+    ensure_tag_existence(Symbol(tag))
+  end
 
   tags_filter = _parse_argument_with_value("--tags", tag_transform)
   exclude_filter = _parse_argument_with_value("--exclude", tag_transform)

--- a/test/test-bad-usage-and-errors.jl
+++ b/test/test-bad-usage-and-errors.jl
@@ -42,3 +42,42 @@ end
     _generate_test_package("some_folder3", TestConstants.args.bestie.robust)
   end
 end
+
+@testitem "Copier temp clone cleanup failure is ignored" tags =
+  [:unit, :fast, :error_handling, :python_integration] setup = [Common] begin
+  Copier = BestieTemplate.Copier
+
+  # Reproduces the OSError raised when Copier's cleanup of its temporary VCS
+  # clone loses the rmtree race (the copy itself has already succeeded).
+  function _cleanup_race_exception(filename)
+    try
+      PythonCall.pyexec("raise OSError(39, 'Directory not empty', '$filename')", @__MODULE__)
+      error("unreachable")
+    catch ex
+      return ex
+    end
+  end
+
+  ex = _cleanup_race_exception("/tmp/copier._vcs.clone.test123/.git/objects")
+  @test Copier._copier_tempdir_from_exception(ex) == "/tmp/copier._vcs.clone.test123"
+
+  # OSError outside a copier temp clone is not swallowed
+  ex_other = _cleanup_race_exception("/tmp/some-other-dir/.git/objects")
+  @test isnothing(Copier._copier_tempdir_from_exception(ex_other))
+  @test_throws PythonCall.PyException Copier._ignore_cleanup_race(() -> throw(ex_other))
+
+  # Non-Python exceptions are not swallowed
+  @test_throws ErrorException Copier._ignore_cleanup_race(() -> error("boom"))
+
+  # The race is swallowed and the leftover temporary clone is removed
+  mktempdir() do dir
+    clone_dir = joinpath(dir, "copier._vcs.clone.test456")
+    mkpath(joinpath(clone_dir, ".git", "objects"))
+    ex_race = _cleanup_race_exception(joinpath(clone_dir, ".git", "objects"))
+    @test isnothing(Copier._ignore_cleanup_race(() -> throw(ex_race)))
+    @test !isdir(clone_dir)
+  end
+
+  # Successful calls pass their value through
+  @test Copier._ignore_cleanup_race(() -> 42) == 42
+end


### PR DESCRIPTION
Copier removes its temporary VCS clone only after the requested operation
has fully completed, and on Linux that rmtree intermittently fails with
OSError: [Errno 39] Directory not empty. The destination files are already
in place at that point, so Copier.copy/recopy/update now detect that
specific failure, treat the operation as successful, and remove the
leftover temporary clone themselves.

Also set JULIA_CONDAPKG_ENV at the top of test/runtests.jl so that
`pkg> test` resolves test/conda-env like the CLI runner does, instead of
building a second pixi env at test/.CondaPkg, and document the pre-commit
fail_fast gotcha on main in CLAUDE.md.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017kMst3KWHexRjY5oJrW7L4
